### PR TITLE
[Feature] Ability for viewers to send each other gold.

### DIFF
--- a/BannerlordTwitch/BLTAdoptAHero/Actions/SendGoldToViewer.cs
+++ b/BannerlordTwitch/BLTAdoptAHero/Actions/SendGoldToViewer.cs
@@ -59,7 +59,9 @@ namespace BLTAdoptAHero.Actions
             }
             else
             {
-                
+                ActionManager.SendReply(context, "{=yJJDmt1q}You do not have {Gold} gold. Current gold amount is {CurrentGold}"
+                    .Translate(("Gold", goldAmount),
+                        ("CurrentGold", heroGold)));
             }
             
             ActionManager.SendNonReply(context,

--- a/BannerlordTwitch/BLTAdoptAHero/Actions/SendGoldToViewer.cs
+++ b/BannerlordTwitch/BLTAdoptAHero/Actions/SendGoldToViewer.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using BannerlordTwitch;
+using BannerlordTwitch.Localization;
+using BannerlordTwitch.Rewards;
+using BannerlordTwitch.Util;
+using BLTAdoptAHero.Annotations;
+using TaleWorlds.CampaignSystem;
+
+namespace BLTAdoptAHero.Actions
+{
+    [LocDisplayName("{=0RJuM4U3}Send Gold"),
+     LocDescription("{=noQfp9fH}Allows viewers to give some of their gold to another viewer."), 
+     UsedImplicitly]
+    public class SendGold : HeroCommandHandlerBase
+    {
+        protected override void ExecuteInternal(Hero adoptedHero, ReplyContext context, object config, Action<string> onSuccess, Action<string> onFailure)
+        {
+            var heroGold = BLTAdoptAHeroCampaignBehavior.Current.GetHeroGold(adoptedHero);
+            
+            if (adoptedHero == null)
+            {
+                ActionManager.SendReply(context, AdoptAHero.NoHeroMessage);
+                return;
+            }
+            
+            if (string.IsNullOrWhiteSpace(context.Args))
+            {
+                ActionManager.SendReply(context,
+                    context.ArgsErrorMessage("{=HAcWwjb8}(recipient) (gold Amount)".Translate()));
+                return;
+            }
+
+            var argParts = context.Args.Trim().Split(' ');
+            if (argParts.Length == 1)
+            {
+                ActionManager.SendReply(context,
+                    context.ArgsErrorMessage("{=HAcWwjb8}(recipient) (gold Amount)".Translate()));
+                return;
+            }
+
+            var targetHero = BLTAdoptAHeroCampaignBehavior.Current.GetAdoptedHero(argParts[0]);
+            {
+                if (targetHero == null)
+                {
+                    ActionManager.SendReply(context, 
+                        "{=vDsYxMKq}Couldn't find recipient '{Name}'".Translate(("Name",argParts[0])));
+                    return;
+                }
+                {
+                    
+                }
+            }
+
+            var goldAmount = int.Parse(argParts[1]);
+            if (heroGold >= goldAmount)
+            {
+                BLTAdoptAHeroCampaignBehavior.Current.ChangeHeroGold(adoptedHero, -goldAmount, isSpending: true);
+                BLTAdoptAHeroCampaignBehavior.Current.ChangeHeroGold(targetHero, goldAmount);
+            }
+            else
+            {
+                
+            }
+            
+            ActionManager.SendNonReply(context,
+                "{=LYO2z7eu}'{GoldAmount}' was transferred from @{FromHero} to @{ToHero}"
+                    .Translate(
+                        ("GoldAmount", goldAmount),
+                        ("FromHero", adoptedHero.FirstName), 
+                        ("ToHero", targetHero.FirstName)));
+        }
+
+        public Type HandlerConfigType => null;
+    }
+}

--- a/BannerlordTwitch/BLTAdoptAHero/Actions/SendGoldToViewer.cs
+++ b/BannerlordTwitch/BLTAdoptAHero/Actions/SendGoldToViewer.cs
@@ -9,20 +9,21 @@ using TaleWorlds.CampaignSystem;
 namespace BLTAdoptAHero.Actions
 {
     [LocDisplayName("{=0RJuM4U3}Send Gold"),
-     LocDescription("{=noQfp9fH}Allows viewers to give some of their gold to another viewer."), 
+     LocDescription("{=noQfp9fH}Allows viewers to give some of their gold to another viewer."),
      UsedImplicitly]
     public class SendGold : HeroCommandHandlerBase
     {
-        protected override void ExecuteInternal(Hero adoptedHero, ReplyContext context, object config, Action<string> onSuccess, Action<string> onFailure)
+        protected override void ExecuteInternal(Hero adoptedHero, ReplyContext context, object config,
+            Action<string> onSuccess, Action<string> onFailure)
         {
             var heroGold = BLTAdoptAHeroCampaignBehavior.Current.GetHeroGold(adoptedHero);
-            
+
             if (adoptedHero == null)
             {
                 ActionManager.SendReply(context, AdoptAHero.NoHeroMessage);
                 return;
             }
-            
+
             if (string.IsNullOrWhiteSpace(context.Args))
             {
                 ActionManager.SendReply(context,
@@ -39,18 +40,13 @@ namespace BLTAdoptAHero.Actions
             }
 
             var targetHero = BLTAdoptAHeroCampaignBehavior.Current.GetAdoptedHero(argParts[0]);
+            if (targetHero == null)
             {
-                if (targetHero == null)
-                {
-                    ActionManager.SendReply(context, 
-                        "{=vDsYxMKq}Couldn't find recipient '{Name}'".Translate(("Name",argParts[0])));
-                    return;
-                }
-                {
-                    
-                }
+                ActionManager.SendReply(context,
+                    "{=vDsYxMKq}Couldn't find recipient '{Name}'".Translate(("Name", argParts[0])));
+                return;
             }
-
+            
             var goldAmount = int.Parse(argParts[1]);
             if (heroGold >= goldAmount)
             {
@@ -59,16 +55,17 @@ namespace BLTAdoptAHero.Actions
             }
             else
             {
-                ActionManager.SendReply(context, "{=yJJDmt1q}You do not have {Gold} gold. Current gold amount is {CurrentGold}"
-                    .Translate(("Gold", goldAmount),
-                        ("CurrentGold", heroGold)));
+                ActionManager.SendReply(context,
+                    "{=yJJDmt1q}You do not have {Gold} gold. Current gold amount is {CurrentGold}"
+                        .Translate(("Gold", goldAmount),
+                            ("CurrentGold", heroGold)));
             }
-            
+
             ActionManager.SendNonReply(context,
                 "{=LYO2z7eu}'{GoldAmount}' was transferred from @{FromHero} to @{ToHero}"
                     .Translate(
                         ("GoldAmount", goldAmount),
-                        ("FromHero", adoptedHero.FirstName), 
+                        ("FromHero", adoptedHero.FirstName),
                         ("ToHero", targetHero.FirstName)));
         }
 

--- a/BannerlordTwitch/BLTAdoptAHero/BLTAdoptAHero.csproj
+++ b/BannerlordTwitch/BLTAdoptAHero/BLTAdoptAHero.csproj
@@ -125,6 +125,7 @@
         <Compile Include="Actions\Retinue.cs" />
         <Compile Include="Actions\RetireMyHero.cs" />
         <Compile Include="Actions\AuctionItem.cs" />
+        <Compile Include="Actions\SendGoldToViewer.cs" />
         <Compile Include="Actions\SetHeroClass.cs" />
         <Compile Include="Actions\SkillXP.cs" />
         <Compile Include="Actions\SummonHero.cs" />


### PR DESCRIPTION
Added the ability for streamers to give their viewers the ability to send each other gold. 

Throughout the process of using BLT, I've come across the issue of viewers using an `Auction Trick` in order to transfer gold to either New/Old viewers participating in a BLT Campaign. Hence the idea came forth to allow viewers to send each other gold with a command without the extra hassle of auctioning off your items.